### PR TITLE
force set charset utf8

### DIFF
--- a/lib/embulk/filter/mysql.rb
+++ b/lib/embulk/filter/mysql.rb
@@ -52,6 +52,7 @@ module Embulk
 
       def init
         @connection = ::Mysql.real_connect(task['host'], task['user'], task['password'], task['database'], task['port'])
+        @connection = 'utf8'
         @statement = @connection.prepare(task['query'])
         @params = task['params']
         @keep_input = task['keep_input']


### PR DESCRIPTION
my.cnfで `default-character-set=utf8` をしてもなぜかlatin1になってしまうので無理矢理utf8にする